### PR TITLE
support case of terraform resource without a name

### DIFF
--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -77,18 +77,38 @@ func processElements(elements model.Document, path string) {
 	}
 }
 
+func processResourcesElements(resourcesElements model.Document, path string) error {
+	for _, v2 := range resourcesElements {
+		switch t := v2.(type) {
+		case []interface{}:
+			return errors.New("failed to process resources")
+		case interface{}:
+			if elements, ok := t.(model.Document); ok {
+				processElements(elements, path)
+			}
+		}
+	}
+	return nil
+}
+
 func processResources(doc model.Document, path string) error {
 	var resourcesElements model.Document
-	for _, resources := range doc { // iterate over resources
-		resourcesElements = resources.(model.Document)
-		for _, v2 := range resourcesElements { // resource name
-			switch t := v2.(type) {
-			case []interface{}:
-				return errors.New("failed to process resources")
-			case interface{}:
-				if elements, ok := t.(model.Document); ok {
-					processElements(elements, path)
+	for _, resources := range doc {
+		switch t := resources.(type) {
+		case []interface{}: // ORCA_KICS: support the case of nameless resources - where we get a list of resources
+			for _, value := range t {
+				resourcesElements = value.(model.Document)
+				err := processResourcesElements(resourcesElements, path)
+				if err != nil {
+					return err
 				}
+			}
+
+		case interface{}:
+			resourcesElements = t.(model.Document)
+			err := processResourcesElements(resourcesElements, path)
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
this PR solves the fatal error we are getting when scanning a TF resources without a name. for exmple for the follwoing, we were getting the following fatal:
`resource "aws_lb" {
  name               = "test-lb-tf"
  internal           = false
  load_balancer_type = "network"
  subnets            = [for subnet in aws_subnet.public : subnet.id]

  enable_deletion_protection = true

  tags = {
    Environment = "production"
  }
}

resource "aws_lb" {
  name               = "test-lb-tf"
  internal           = false
  load_balancer_type = "network"
  subnets            = [for subnet in aws_subnet.public : subnet.id]

  enable_deletion_protection = true

  tags = {
    Environment = "production"
  }
}`

the error we are getting:
```
panic: interface conversion: interface {} is []interface {}, not model.Document

goroutine 13 [running]:
github.com/Checkmarx/kics/pkg/parser/terraform.processResources(0x1e43a80?, {0x4000230f40, 0xa})
	/app/pkg/parser/terraform/terraform.go:75 +0x1d8
github.com/Checkmarx/kics/pkg/parser/terraform.addExtraInfo({0x400012e250?, 0x1, 0x1}, {0x4000230f40, 0xa})
	/app/pkg/parser/terraform/terraform.go:93 +0xac
github.com/Checkmarx/kics/pkg/parser/terraform.(*Parser).Parse(0x4000f1d300, {0x4000230f40, 0xa}, {0x4000c426c0, 0x223, 0x240})
	/app/pkg/parser/terraform/terraform.go:133 +0x188
github.com/Checkmarx/kics/pkg/parser.(*Parser).Parse(0x4000f255c0, {0x4000230f40, 0xa}, {0x4000c426c0, 0x223, 0x240})
	/app/pkg/parser/parser.go:128 +0x120
github.com/Checkmarx/kics/pkg/kics.(*Service).sink(0x40005e9730, {0x2765410, 0x400013a000}, {0x4000230f40, 0xa}, {0x210a8c2, 0x7}, {0x2748400, 0x400012e040}, {0x4001200000, ...})
	/app/pkg/kics/sink.go:42 +0x134
github.com/Checkmarx/kics/pkg/kics.(*Service).PrepareSources.func1({0x2765410, 0x400013a000}, {0x4000230f40, 0xa}, {0x2753608?, 0x400012e040})
	/app/pkg/kics/service.go:71 +0xa8
github.com/Checkmarx/kics/pkg/engine/provider.(*FileSystemSourceProvider).GetSources(0x40001284c0, {0x2765410, 0x400013a000}, 0x87354?, 0x40004c0dc0, 0x0?)
	/app/pkg/engine/provider/filesystem.go:129 +0x140
github.com/Checkmarx/kics/pkg/kics.(*Service).PrepareSources(0x40005e9730, {0x2765410, 0x400013a000}, {0x210a8c2, 0x7}, 0x4000cf8120?, 0x4000cf8180?)
	/app/pkg/kics/service.go:67 +0x1c0
created by github.com/Checkmarx/kics/pkg/scanner.PrepareAndScan
	/app/pkg/scanner/scanner.go:24 +0xb4
```

**Proposed Changes**
-
-
-

I submit this contribution under the Apache-2.0 license.
